### PR TITLE
Fix python2\3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 setup(name='py-zabbix',
-      version='0.6.0',
+      version='0.6.1',
       description='Python modules for work with zabbix.',
       url='https://github.com/blacked/py-zabbix',
       author='Alexey Dubkov',


### PR DESCRIPTION
Ok. That compatibility issue bothered me. Just add checking version. Also now it will raise exception if something goes wrong, rather then quite exit.