### PR TITLE
Qualify invocation to `api_version` to clarify the example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ result = zapi.do_request('host.getobjects', {'status':1})
 
 #### Get Zabbix API version
 ```python
-api_version()
+zapi.api_version()
 ```
 
 #### Get object ID


### PR DESCRIPTION
I think this makes the documentation more clear that the `api_version` call is a method invocation.