### PR TITLE
python2 compatibility

### DIFF
--- a/zabbix/sender.py
+++ b/zabbix/sender.py
@@ -1,4 +1,3 @@
-import configparser
 import json
 import logging
 import socket
@@ -11,8 +10,10 @@ Python3 compatibility
 """
 try:
     from StringIO import StringIO
+    import ConfigParser as configparser
 except ImportError:
     from io import StringIO
+    import configparser
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
ConfigParser was renamed to configparser in Python3 so there needs to be check for import
https://docs.python.org/2/library/configparser.html