### PR TITLE
fix UnboundLocalError on malformed url

### DIFF
--- a/zabbix/api.py
+++ b/zabbix/api.py
@@ -162,8 +162,8 @@ class ZabbixAPI(object):
                 res = urllib2.urlopen(req)
 
             response_json = json.load(res)
-        except ValueError:
-            raise ZabbixAPIException("Unable to parse json: %" % res)
+        except ValueError as e:
+            raise ZabbixAPIException("Unable to parse json: %s" % e.message)
 
         logger.debug("Response Body: %s" % json.dumps(response_json, indent=4,
                                                       separators=(',', ': ')))


### PR DESCRIPTION
Currently when trying to initialize ZabbixAPI object with a malformed URL, you get an UnboundLocalError.

The problems were usage of the uninitialized 'res' variable, and invalid format string.
I fixed the format string and replaced 'res' with the exception's error message.