### PR TITLE
Added __repr__ representation for the class ZabbixSender.

### DIFF
--- a/zabbix/sender.py
+++ b/zabbix/sender.py
@@ -2,7 +2,6 @@ import json
 import logging
 import socket
 import struct
-import sys
 import time
 
 """

--- a/zabbix/sender.py
+++ b/zabbix/sender.py
@@ -77,6 +77,16 @@ class ZabbixSender(object):
 
         logger.debug('%s(%s)', self.cn, self.zabbix_uri)
 
+    def __repr__(self):
+        """
+        Represent detailed ZabbixSender view.
+        """
+
+        result = json.dumps(self.__dict__)
+        logger.debug('%s: %s', self.__class__.__name__, result)
+
+        return result
+
     @classmethod
     def __load_from_config(cls, config_file):
         """


### PR DESCRIPTION
Just added `__repr__` representation for the class ZabbixSender. It is strange that for the class ZabbixMetric it was created.

P.S. sys module never used in sender.py file. Removed it.