### PR TITLE
fix apiinfo.version and user.login. updated docs

### DIFF
--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -110,7 +110,7 @@ class ZabbixAPI(object):
     >>> z.do_request('apiinfo.version')
     >>> {u'jsonrpc': u'2.0', u'result': u'2.2.1', u'id': u'1'}
     >>> # Get all disabled hosts
-    >>> z.host.getobjects(status=1)
+    >>> z.host.get(status=1)
     >>> # or
     >>> z.do_request('host.getobjects', {'status': 1})
     """
@@ -179,9 +179,13 @@ class ZabbixAPI(object):
             'jsonrpc': '2.0',
             'method': method,
             'params': params or {},
-            'auth': self.auth,
             'id': '1',
         }
+
+        # apiinfo.version and user.login doesn't require auth token
+        if (self.auth
+            and (method not in ('apiinfo.version', 'user.login'))):
+            request_json['auth'] = self.auth
 
         # We shoul explicitly disable cert verification to support
         # self-signed certs with urllib2 since Python 2.7.9

--- a/tests/test_Functional_API.py
+++ b/tests/test_Functional_API.py
@@ -14,3 +14,8 @@ class FunctionalAPI(TestCase):
         except ZabbixAPIException:
             self.fail('Can\'t login to Zabbix')
 
+    def test_get_api_version(self):
+        zapi = ZabbixAPI(url='http://127.0.0.1',
+                         user='Admin',
+                         password='zabbix')
+        self.assertEqual(zapi.api_version(), '3.0.1')


### PR DESCRIPTION
This PR address multiple issues: [#35](https://github.com/blacked/py-zabbix/issues/35), [#34](https://github.com/blacked/py-zabbix/issues/34), [#5](https://github.com/blacked/py-zabbix/issues/5).