### PR TITLE
Check time type

### DIFF
--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -23,7 +23,6 @@ import logging
 import socket
 import struct
 import re
-import warnings
 
 # For python 2 and 3 compatibility
 try:
@@ -117,13 +116,10 @@ class ZabbixMetric(object):
         self.key = str(key)
         self.value = str(value)
         if clock:
-            if isinstance(clock, float):
-                self.clock = int('float')
-            elif isinstance(clock, int):
-                self.clock = clock
+            if isinstance(clock, (float, int)):
+                self.clock = int(clock)
             else:
-                warnings.warn('Clock must be int type. Recived {type} type'.format(type=type(clock)))
-                self.clock = None
+                raise Exception('Clock must be time in unixtime format')
 
     def __repr__(self):
         """Represent detailed ZabbixMetric view."""

--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -23,7 +23,7 @@ import logging
 import socket
 import struct
 import re
-import time
+import warnings
 
 # For python 2 and 3 compatibility
 try:
@@ -117,7 +117,13 @@ class ZabbixMetric(object):
         self.key = str(key)
         self.value = str(value)
         if clock:
-            self.clock = clock
+            if isinstance(clock, float):
+                print('float')
+            elif isinstance(clock, int):
+                self.clock = clock
+            else:
+                warnings.warn('Clock must be int type. Recived {type} type'.format(type=type(clock)))
+                self.clock = None
 
     def __repr__(self):
         """Represent detailed ZabbixMetric view."""

--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -118,7 +118,7 @@ class ZabbixMetric(object):
         self.value = str(value)
         if clock:
             if isinstance(clock, float):
-                print('float')
+                self.clock = int('float')
             elif isinstance(clock, int):
                 self.clock = clock
             else:

--- a/tests/test_Functional_API.py
+++ b/tests/test_Functional_API.py
@@ -27,7 +27,7 @@ class FunctionalAPI(TestCase):
                          user='Admin',
                          password='zabbix')
         if os.environ['ZABBIX_VERSION'] == '3':
-            self.assertEqual(zapi.api_version(), '3.0.2')
+            self.assertEqual(zapi.api_version(), '3.0.3')
         elif os.environ['ZABBIX_VERSION'] == '2':
             self.assertEqual(zapi.api_version(), '2.4.7')
         else:

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -13,6 +13,7 @@ except ImportError:
     autospec = True
 
 from pyzabbix import ZabbixMetric, ZabbixSender, ZabbixResponse
+import warnings
 
 
 class TestZabbixResponse(TestCase):
@@ -31,6 +32,13 @@ class TestZabbixMetric(TestCase):
         self.assertEqual(zm.host, 'host1')
         self.assertEqual(zm.key, 'key1')
         self.assertEqual(zm.clock, 1457358608)
+
+    def test_init_warn(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            zm = ZabbixMetric('host1', 'key1', 100500, '1457358608.01')
+            self.assertEqual(len(w), 1)
+
 
     def test_repr(self):
         zm = ZabbixMetric('host1', 'key1', 100500)

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -1,6 +1,6 @@
 import json
 import os
-import re
+
 import struct
 
 from unittest import TestCase, skip
@@ -13,7 +13,6 @@ except ImportError:
     autospec = True
 
 from pyzabbix import ZabbixMetric, ZabbixSender, ZabbixResponse
-import warnings
 
 
 class TestZabbixResponse(TestCase):
@@ -33,12 +32,9 @@ class TestZabbixMetric(TestCase):
         self.assertEqual(zm.key, 'key1')
         self.assertEqual(zm.clock, 1457358608)
 
-    def test_init_warn(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            zm = ZabbixMetric('host1', 'key1', 100500, '1457358608.01')
-            self.assertEqual(len(w), 1)
-
+    def test_init_err(self):
+        with self.assertRaises(Exception):
+            ZabbixMetric('host1', 'key1', 100500, '1457358608.01')
 
     def test_repr(self):
         zm = ZabbixMetric('host1', 'key1', 100500)


### PR DESCRIPTION
I saw many users using the library trying to pass the time.time() during metric object creation