### PR TITLE
Added sending list of metrics in pieces.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,3 @@
+1.1.2 (2016-07-28)
+==================
+-  Added parameter **chunk\_size** for object **ZabbixSender**

--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -1,4 +1,4 @@
 from .api import ZabbixAPI, ZabbixAPIException, ssl_context_compat
 from .sender import ZabbixMetric, ZabbixSender, ZabbixResponse
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'

--- a/tests/test_Functional_Sender.py
+++ b/tests/test_Functional_Sender.py
@@ -15,10 +15,10 @@ class FunctionalSender(TestCase):
             ZabbixMetric('host1', 'key1', 33.1, cur_date_unix)
         ]
 
-        z = ZabbixSender('127.0.0.1', 10051).send(m)
+        z = ZabbixSender('127.0.0.1', 10051, chunk_size=1).send(m)
 
         self.assertIsInstance(z, ZabbixResponse)
         self.assertEqual(z.total, 2)
         self.assertEqual(z.processed, 2)
         self.assertEqual(z.failed, 0)
-        self.assertEqual(z.chunk, 1)
+        self.assertEqual(z.chunk, 2)

--- a/tests/test_Functional_Sender_Old.py
+++ b/tests/test_Functional_Sender_Old.py
@@ -16,10 +16,10 @@ class FunctionalSender(TestCase):
             ZabbixMetric('host1', 'key1', 33.1, cur_date_unix)
         ]
 
-        z = ZabbixSender('127.0.0.1', 10051).send(m)
+        z = ZabbixSender('127.0.0.1', 10051, chunk_size=1).send(m)
 
         self.assertIsInstance(z, ZabbixResponse)
         self.assertEqual(z.total, 2)
         self.assertEqual(z.processed, 2)
         self.assertEqual(z.failed, 0)
-        self.assertEqual(z.chunk, 1)
+        self.assertEqual(z.chunk, 2)


### PR DESCRIPTION
If the list of metrics is too large (more than 250 items) it will be
divided into pieces each of which will be sent separately. The idea and
the specific number of metrics taken from the original implementation of
zabbix_sender.

The number of metrics on one piece can be optionally specified when
creating the object ZabbixSender.