### PR TITLE
Expand regex to work with alternate Zabbix output

### DIFF
--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -49,7 +49,7 @@ class ZabbixResponse(object):
         self._time = 0
         self._chunk = 0
         pattern = (r'[Pp]rocessed:? (\d*);? [Ff]ailed:? (\d*);? '
-                   '[Tt]otal:? (\d*);? [Ss]econds spent:? (\d*\.\d*)')
+                    '[Tt]otal:? (\d*);? [Ss]econds spent:? (\d*\.\d*)')
         self._regex = re.compile(pattern)
 
     def __repr__(self):

--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -49,7 +49,7 @@ class ZabbixResponse(object):
         self._time = 0
         self._chunk = 0
         pattern = (r'[Pp]rocessed:? (\d*);? [Ff]ailed:? (\d*);? '
-                    '[Tt]otal:? (\d*);? [Ss]econds spent:? (\d*\.\d*)')
+                   '[Tt]otal:? (\d*);? [Ss]econds spent:? (\d*\.\d*)')
         self._regex = re.compile(pattern)
 
     def __repr__(self):

--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -48,8 +48,8 @@ class ZabbixResponse(object):
         self._total = 0
         self._time = 0
         self._chunk = 0
-        pattern = (r'[Pp]rocessed:? (\d*);? [Ff]ailed:? (\d*);? [Tt]otal:? (\d*);? '
-                   '[Ss]econds spent:? (\d*\.\d*)')
+        pattern = (r'[Pp]rocessed:? (\d*);? [Ff]ailed:? (\d*);? '
+                   '[Tt]otal:? (\d*);? [Ss]econds spent:? (\d*\.\d*)')
         self._regex = re.compile(pattern)
 
     def __repr__(self):

--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -48,8 +48,8 @@ class ZabbixResponse(object):
         self._total = 0
         self._time = 0
         self._chunk = 0
-        pattern = (r'processed: (\d*); failed: (\d*); total: (\d*); '
-                   'seconds spent: (\d*\.\d*)')
+        pattern = (r'[Pp]rocessed:? (\d*);? [Ff]ailed:? (\d*);? [Tt]otal:? (\d*);? '
+                   '[Ss]econds spent:? (\d*\.\d*)')
         self._regex = re.compile(pattern)
 
     def __repr__(self):


### PR DESCRIPTION
Sometimes, Zabbix returns:
processed: 90; failed: 8; total: 98; seconds spent: 0.001539
which py-zabbix is looking for.
Sometimes, for reasons I don't understand, it uses this format:
Processed 90 Failed 8 Total 98 Seconds spent 0.001539
So, this alters the regex to handle both formats